### PR TITLE
Add index support

### DIFF
--- a/lib/create.js
+++ b/lib/create.js
@@ -19,9 +19,15 @@ const notFoundError = (ctx, message) => {
 
 /** @lends sugoEndpointHtml */
 function create (renderers, options = {}) {
+  if (typeof renderers === 'function') {
+    renderers = Object.assign({}, { index: renderers }, renderers)
+  }
   let endpoint = co.wrap(function * middleware (ctx) {
     debug('handle')
-    let { module: moduleName, method: methodName } = ctx.params
+    let {
+      module: moduleName,
+      method: methodName = 'index'
+    } = ctx.params
     let render = renderers[ camelcase(moduleName) ] || renderers[ moduleName ]
     if (!render) {
       notFoundError(ctx, `Renderer not found: ${moduleName}`)

--- a/test/create_test.js
+++ b/test/create_test.js
@@ -18,6 +18,7 @@ describe('create', () => {
   before(() => co(function * () {
     let endpoint = create({
       account: {
+        index: () => '<!DOCTYPE html><html><body>The Index!</body></html>',
         purchaseHistory: () => '<!DOCTYPE html><html><body>hoge</body></html>'
       }
     })
@@ -25,6 +26,7 @@ describe('create', () => {
     let port = yield aport()
     server = sgServer({
       endpoints: {
+        '/:module': { GET: endpoint }, // For index
         '/:module/:method': { GET: endpoint }
       }
     })
@@ -46,6 +48,17 @@ describe('create', () => {
     equal(headers[ 'content-type' ], 'text/html; charset=utf-8')
     equal(statusCode, 200)
     equal(body, '<!DOCTYPE html><html><body>hoge</body></html>')
+  }))
+
+  it('Get index', () => co(function * () {
+    let { body, statusCode, headers } = yield request({
+      method: 'GET',
+      url: `${baseUrl}/account`
+    })
+    ok(body)
+    equal(headers[ 'content-type' ], 'text/html; charset=utf-8')
+    equal(statusCode, 200)
+    equal(body, '<!DOCTYPE html><html><body>The Index!</body></html>')
   }))
 })
 


### PR DESCRIPTION
メソッド名を省略した時にindexが呼ばれるようにした。

"/account" -> `account#index`メソッド
"/account/purchase-history" -> 　`account#purchaseHistory`メソッド